### PR TITLE
Fix the shard.yml setup in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Add this to your application's `shard.yml`:
 
 ```yaml
 dependencies:
-  sodium.cr:
+  sodium:
     github: didactic-drunk/sodium.cr
 ```
 


### PR DESCRIPTION
The shard name should be "sodium" without .cr otherwise we get an error when running `shards install`