### PR TITLE
Crystal <= 0.34 backport `final` methods from crystal 0.35.

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,11 +199,11 @@ data = "data".to_slice
 # output_size, key, salt, and personal are optional.
 digest = Sodium::Digest::Blake2b.new out_size, key: key, salt: salt, personal: personal
 digest.update data
-output = d.hexdigest
+output = d.hexfinal
 
 digest.reset # Reuse existing object to hash again.
 digest.update data
-output = d.hexdigest
+output = d.hexfinal
 ```
 
 ### Key derivation

--- a/benchmarks/blake2b.cr
+++ b/benchmarks/blake2b.cr
@@ -15,14 +15,14 @@ Benchmark.ips(warmup: 0.5) do |bm|
     bm.report "blake2b new obj per iter #{size}" do
       d = Sodium::Digest::Blake2b.new 64
       d.update bufs[i]
-      d.digest
+      d.final
     end
 
     d = Sodium::Digest::Blake2b.new output_size
     bm.report "blake2b reset per iter #{size}" do
       d.reset
       d.update bufs[i]
-      d.digest
+      d.final
     end
 
     d = Sodium::Digest::Blake2b.new output_size
@@ -30,7 +30,7 @@ Benchmark.ips(warmup: 0.5) do |bm|
     bm.report "blake2b reset reusing buffer per iter #{size}" do
       d.reset
       d.update bufs[i]
-      d.finish dst
+      d.final dst
     end
   end
 
@@ -39,17 +39,23 @@ Benchmark.ips(warmup: 0.5) do |bm|
       bm.report "#{arg} new obj per iter  #{size}" do
         d = OpenSSL::Digest.new arg
         d.update bufs[i]
-        d.digest
+        d.final
       end
 
       d = OpenSSL::Digest.new arg
       bm.report "#{arg} reset per iter #{size}" do
         d.reset
         d.update bufs[i]
-        d.digest
+        d.final
       end
 
-      # OpenSSL::Digest doesn't have a public .finish (yet)
+      d = OpenSSL::Digest.new arg
+      dst = Bytes.new d.digest_size
+      bm.report "#{arg} reset reusing buffer per iterr #{size}" do
+        d.reset
+        d.update bufs[i]
+        d.final dst
+      end
     end
   end
 end

--- a/spec/sodium/digest/blake2b_spec.cr
+++ b/spec/sodium/digest/blake2b_spec.cr
@@ -34,7 +34,7 @@ describe Sodium::Digest::Blake2b do
     test_vectors.each do |vec|
       d = Sodium::Digest::Blake2b.new 64, key: vec[:key].hexbytes
       d.update vec[:input].hexbytes
-      d.hexdigest.should eq vec[:output]
+      d.hexfinal.should eq vec[:output]
     end
 
     more_vectors.each do |vec|
@@ -42,7 +42,7 @@ describe Sodium::Digest::Blake2b do
       personal = vec[:personal].empty? ? nil : vec[:personal].hexbytes
       d = Sodium::Digest::Blake2b.new vec[:out_len], key: vec[:key].hexbytes, salt: salt, personal: personal
       d.update vec[:input].hexbytes
-      d.hexdigest.should eq vec[:output]
+      d.hexfinal.should eq vec[:output]
     end
   end
 
@@ -58,15 +58,15 @@ describe Sodium::Digest::Blake2b do
 
     d = Sodium::Digest::Blake2b.new key: key, salt: salt, personal: personal
     d.update "foo".to_slice
-    output = d.hexdigest
+    output = d.hexfinal
 
     d = Sodium::Digest::Blake2b.new key: key, salt: salt2, personal: personal
     d.update "foo".to_slice
-    saltout = d.hexdigest
+    saltout = d.hexfinal
 
     d = Sodium::Digest::Blake2b.new key: key, salt: salt, personal: personal2
     d.update "foo".to_slice
-    personalout = d.hexdigest
+    personalout = d.hexfinal
 
     output.should_not eq saltout
     output.should_not eq personalout


### PR DESCRIPTION
Crystal = 0.35 use new Digest::Base interface.
Crystal > 0.35 futureport `hexfinal` method.