### PR TITLE
fix bash shell reference in build/env.sh from bin/sh -> bin/bash

### DIFF
--- a/build/env.sh
+++ b/build/env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Overridable.
 [ -z "$LIBSODIUM_BUILD_DIR" ] && LIBSODIUM_BUILD_DIR=`pwd`/build


### PR DESCRIPTION
Signed-off-by: Bet3lgeuse <bet3lgeuse@protonmail.com>. 

bin/sh breaks on Debian 10. The other files in build point to bin/bash as well. 