### PR TITLE
Fix version mismatch (shard.yml vs release tag)

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 ---
 name: sodium
-version: 1.2.1
+version: 1.2.3
 authors:
 - Andrew Hamon <andrew@hamon.cc>
 - Didactic Drunk <1479616+didactic-drunk@users.noreply.github.com>


### PR DESCRIPTION
Installing this shard currently gives the following warning:
`Shard "sodium" version (1.2.1) doesn't match tag version (1.2.2)`

Merging this and tagging a new release as `v1.2.3` should fix it. ;)