### PR TITLE
Fix `#encrypt_detached` for crystal 1.2.0

### DIFF
--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -9,9 +9,24 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: "crystal: ${{ matrix.crystal }}, stable: ${{ matrix.stable }}"
+    continue-on-error: ${{ !matrix.stable }}
+    strategy:
+      matrix:
+        stable: [true]
+        crystal:
+          - 0.36.0
+          - 0.36.1
+          - 1.0.0
+          - 1.1.0
+          - 1.1.1
+          - 1.2.0
+        include:
+          - crystal: nightly
+            stable: false
 
     container:
-      image: crystallang/crystal
+      image: crystallang/crystal:${{ matrix.crystal }}
 
     steps:
     - uses: actions/checkout@v2
@@ -31,8 +46,7 @@ jobs:
     - name: Install dependencies
       run: shards install
     - name: Run tests
-      run: crystal spec -Dpreview_mt --order random 
-#      run: crystal spec -Dpreview_mt --order random --error-on-warnings
+      run: crystal spec -Dpreview_mt --order random
     - name: Run bulid
       run: shards build -Dpreview_mt
     - name: Run format

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -16,8 +16,6 @@ jobs:
       matrix:
         stable: [true]
         crystal:
-          - 0.36.0
-          - 0.36.1
           - 1.0.0
           - 1.1.0
           - 1.1.1

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -12,6 +12,7 @@ jobs:
     name: "crystal: ${{ matrix.crystal }}, stable: ${{ matrix.stable }}"
     continue-on-error: ${{ !matrix.stable }}
     strategy:
+      fail-fast: false
       matrix:
         stable: [true]
         crystal:
@@ -54,4 +55,3 @@ jobs:
     - name: Failed
       if: ${{ failure() }}
       run: "[ -f libsodium_install.out ] && cat libsodium_install.out"
-

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 1.2.3
 authors:
 - Andrew Hamon <andrew@hamon.cc>
 - Didactic Drunk <1479616+didactic-drunk@users.noreply.github.com>
-crystal: ">= 0.36.0"
+crystal: ">= 1.0.0"
 targets:
   blake2b_hash:
     main: examples/blake2b_hash.cr

--- a/src/sodium/cipher/aead/chalsa.cr
+++ b/src/sodium/cipher/aead/chalsa.cr
@@ -103,7 +103,7 @@ module Sodium::Cipher::Aead
       # `src` and `dst` may be the same object but should not overlap.
       # May supply `mac`, otherwise a new one is returned.
       # May supply `additional`
-      def encrypt_detached(src : Bytes, dst : Bytes? = nil, nonce : Sodium::Nonce? = nil, *, mac : Bytes? = nil, additional : String | Bytes | Nil = nil) : {Bytes, Bytes, Sodium::Nonce}
+      def encrypt_detached(src : Bytes, dst : Bytes? = nil, *, nonce : Sodium::Nonce? = nil, mac : Bytes? = nil, additional : String | Bytes | Nil = nil) : {Bytes, Bytes, Sodium::Nonce}
         dst ||= Bytes.new src.bytesize
         nonce ||= Sodium::Nonce.random
         mac ||= Bytes.new MAC_SIZE


### PR DESCRIPTION
Fixes an issue with crystal 1.2.0
Additionally adds a matrix of all the supported versions as stated in the `shard.yml`